### PR TITLE
Add slight offset to chests and other 3x3 grids

### DIFF
--- a/common/src/main/java/com/hammy275/immersivemc/client/immersive/ImmersiveBuilderImpl.java
+++ b/common/src/main/java/com/hammy275/immersivemc/client/immersive/ImmersiveBuilderImpl.java
@@ -84,15 +84,16 @@ public class ImmersiveBuilderImpl<E, S extends NetworkStorage> implements Immers
         Vec3 right = new Vec3(1, 0, 0).scale(distBetweenBoxes);
         Vec3 up = new Vec3(0, 1, 0).scale(distBetweenBoxes);
         Vec3 down = new Vec3(0, -1, 0).scale(distBetweenBoxes);
-        addHitbox(relativeHitboxInfo.cloneWithAddedOffset(up.add(left)));
-        addHitbox(relativeHitboxInfo.cloneWithAddedOffset(up));
-        addHitbox(relativeHitboxInfo.cloneWithAddedOffset(up.add(right)));
-        addHitbox(relativeHitboxInfo.cloneWithAddedOffset(left));
-        addHitbox(relativeHitboxInfo);
-        addHitbox(relativeHitboxInfo.cloneWithAddedOffset(right));
-        addHitbox(relativeHitboxInfo.cloneWithAddedOffset(down.add(left)));
-        addHitbox(relativeHitboxInfo.cloneWithAddedOffset(down));
-        addHitbox(relativeHitboxInfo.cloneWithAddedOffset(down.add(right)));
+        Vec3 offset = new Vec3(0.0002, 0.0002, 0.0002); //Minor offset for each hitbox to prevent Z-fighting
+        addHitbox(relativeHitboxInfo.cloneWithAddedOffset(up.add(left).add(offset)));
+        addHitbox(relativeHitboxInfo.cloneWithAddedOffset(up.add(offset.scale(2))));
+        addHitbox(relativeHitboxInfo.cloneWithAddedOffset(up.add(right).add(offset.scale(3))));
+        addHitbox(relativeHitboxInfo.cloneWithAddedOffset(left.add(offset.scale(4))));
+        addHitbox(relativeHitboxInfo.cloneWithAddedOffset(offset.scale(5)));
+        addHitbox(relativeHitboxInfo.cloneWithAddedOffset(right.add(offset.scale(6))));
+        addHitbox(relativeHitboxInfo.cloneWithAddedOffset(down.add(left).add(offset.scale(7))));
+        addHitbox(relativeHitboxInfo.cloneWithAddedOffset(down.add(offset.scale(8))));
+        addHitbox(relativeHitboxInfo.cloneWithAddedOffset(down.add(right).add(offset.scale(9))));
         return this;
     }
 

--- a/common/src/main/java/com/hammy275/immersivemc/client/immersive/ImmersiveChest.java
+++ b/common/src/main/java/com/hammy275/immersivemc/client/immersive/ImmersiveChest.java
@@ -81,7 +81,6 @@ public class ImmersiveChest extends AbstractImmersive<ChestInfo, ListOfItemsStor
 
     @Override
     public void render(ChestInfo info, PoseStack stack, ImmersiveRenderHelpers helpers, float partialTicks) {
-        Direction forward = info.forward;
 
         if (info.isOpen) {
             for (int i = 0; i < 27; i++) {
@@ -131,21 +130,27 @@ public class ImmersiveChest extends AbstractImmersive<ChestInfo, ListOfItemsStor
             int endTop = startTop + 9;
             for (int z = startTop; z < endTop; z++) {
                 Vec3 pos = positions[z % 9];
-                info.getAllHitboxes().get(z).box = AABB.ofSize(pos.add(0, -0.2, 0), hitboxSize, hitboxSize, hitboxSize);
+                double offset = (z - startTop) * 0.0002; //Minor offset for each hitbox to prevent Z-fighting
+                info.getAllHitboxes().get(z).box = AABB.ofSize(pos.add(offset, -0.2 + offset, offset),
+                        hitboxSize, hitboxSize, hitboxSize);
             }
 
             int startMid = 9 * info.getNextRow(info.getRowNum()) + 27 * i;
             int endMid = startMid + 9;
             for (int z = startMid; z < endMid; z++) {
                 Vec3 pos = positions[z % 9];
-                info.getAllHitboxes().get(z).box = AABB.ofSize(pos.add(0, -0.325, 0), 0, 0, 0);
+                double offset = (z - startMid) * 0.0002; //Minor offset for each hitbox to prevent Z-fighting
+                info.getAllHitboxes().get(z).box = AABB.ofSize(pos.add(offset, -0.325 + offset, offset),
+                        0, 0, 0);
             }
 
             int startBot = 9 * info.getNextRow(info.getNextRow(info.getRowNum())) + 27 * i;
             int endBot = startBot + 9;
             for (int z = startBot; z < endBot; z++) {
                 Vec3 pos = positions[z % 9];
-                info.getAllHitboxes().get(z).box = AABB.ofSize(pos.add(0, -0.45, 0), 0, 0, 0);
+                double offset = (z - startBot) * 0.0002; //Minor offset for each hitbox to prevent Z-fighting
+                info.getAllHitboxes().get(z).box = AABB.ofSize(pos.add(offset, -0.45 + offset, offset),
+                        0, 0, 0);
             }
         }
 
@@ -185,10 +190,10 @@ public class ImmersiveChest extends AbstractImmersive<ChestInfo, ListOfItemsStor
 
                 double diff0 = current0.y - info.lastY0;
                 double diff1 = current1.y - info.lastY1;
-                if (!Util.getFirstIntersect(current0, info.openCloseHitboxes).isPresent()) {
+                if (Util.getFirstIntersect(current0, info.openCloseHitboxes).isEmpty()) {
                     diff0 = 0;
                 }
-                if (!Util.getFirstIntersect(current1, info.openCloseHitboxes).isPresent()) {
+                if (Util.getFirstIntersect(current1, info.openCloseHitboxes).isEmpty()) {
                     diff1 = 0;
                 }
 


### PR DESCRIPTION

![2024-09-04_02 04 40](https://github.com/user-attachments/assets/15a24122-be19-4772-bbe2-0cd7319fec4a)

Managed to add a very subtle escalating +0.0002 offset on all axes to each hitbox, which fixes the flickering of 2D items on all axes in tight 3x3 grid configurations.

Additional change:
- Light code refactor via IntelliJ recommendations

Known issue:
- Items with transparency, such as Glass Panes, may still take turns rendering on top of one another depending on angle. This is more of a transparency sorting issue.

Note: Probably needs to be backported to previous versions as well.